### PR TITLE
[고도화] 엔티티 코드 리팩토링 - equals(), hashcode()에서 필드 접근을 getter로 바꾸기

### DIFF
--- a/src/main/java/com/primarchan/projectboard/domain/Article.java
+++ b/src/main/java/com/primarchan/projectboard/domain/Article.java
@@ -61,13 +61,13 @@ public class Article extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Article article)) return false;
-        return id != null && id.equals(article.id);
+        if (!(o instanceof Article that)) return false;
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 
 }

--- a/src/main/java/com/primarchan/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/primarchan/projectboard/domain/ArticleComment.java
@@ -50,11 +50,12 @@ public class ArticleComment extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
+
 }

--- a/src/main/java/com/primarchan/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/primarchan/projectboard/domain/UserAccount.java
@@ -44,13 +44,13 @@ public class UserAccount extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount userAccount)) return false;
-        return userId != null && userId.equals(userAccount.userId);
+        if (!(o instanceof UserAccount that)) return false;
+        return this.getUserId() != null && this.getUserId().equals(that.getUserId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 
 }


### PR DESCRIPTION
Spring Data JPA 로 Entity 를 다룰 때, Entity 데이터는 Hibernate 구현체가 만든 프록시 객체를 이용하여 지연 로딩될 수 있다.
따라서 Entity 를 조회할 때, 필드에 직접 접근하면 `id == null` 인 상황이 있을 수 있고, 올바른 비교를 하지 못하게 된다.
getter 를 사용하면 이러한 이슈를 예방할 수 있다.

* [ ] Article
* [ ] ArticleComment
* [ ] UserAccount